### PR TITLE
New extension methods and docs

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -3,58 +3,29 @@
 [![NuGet](https://img.shields.io/nuget/v/LightInject.Microsoft.DependencyInjection.svg?maxAge=2592000)]()
 [![GitHub tag](https://img.shields.io/github/tag/seesharper/LightInject.Microsoft.DependencyInjection.svg?maxAge=2592000)]()
 
-Enables **LightInject** to be used as the service container in ASP.NET Core and Entity Framework 7 applications.
+Implements the [Microsoft.Extensions.DependencyInjection.Abstractions](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Abstractions/) and makes it possible to create an `IServiceProvider` that is 100% compatible with the [Microsoft.Extensions.DependencyInjection.Specification.Tests](https://www.nuget.org/packages/Microsoft.Extensions.DependencyInjection.Specification.Tests). 
+
+> Note: This package is NOT meant to be used directly with AspNetCore applications. If the target application is an AspNetCore application, use the [LightInject.Microsoft.AspNetCore.Hosting](https://www.nuget.org/packages/LightInject.Microsoft.AspNetCore.Hosting/) package instead. 
 
 ## Installing
-```
-"dependencies": {
-  "LightInject.Microsoft.DependencyInjection": "<version>"
-}
+
+```shell
+dotnet add package LightInject.Microsoft.DependencyInjection
 ```
 
 ## Usage
-```
-public class Startup
-{       
-    public IServiceProvider ConfigureServices(IServiceCollection services)
-    {
-        var container = new ServiceContainer();
-        return container.CreateServiceProvider(services);
-    }
-    
-    public void Configure(IApplicationBuilder app)
-    {          
-        app.Run(async (context) =>
-        {
-            await context.Response.WriteAsync("Hello from LightInject");
-        });
-    }
-}
+```c#
+var services = new ServiceCollection();
+services.AddTransient<Foo>();
+var provider = services.CreateLightInjectServiceProvider();
 ```
 
-## Controllers
-
-By default, controllers are not actually created by *LightInject*. They are created by the ASP.NET infrastructure and uses LightInject to resolve its dependencies. To enable LightInject to create the controller instances, we need to add the following line.
-
-```csharp
-services.AddMvc().AddControllersAsServices();
-```
-
-
-
-## .Net Core 2.0
-
-**Requirements:**
-
-* &gt;= LightInject 5.1.0
-* &gt;= LightInject.Microsoft.DependencyInjection 2.0.3
-
-In addition we need to turn of propertyinjection
+It is also possible to create an `IServiceProvider` directly from an `IServiceContainer` instance.
 
 ```c#
-var containerOptions = new ContainerOptions { EnablePropertyInjection = false } 
-var container = new ServiceContainer(containerOptions);
+var container = new ServiceContainer(Options.Default.WithMicrosoftSettings);
+var provider = container.CreateServiceProvider();
 ```
 
-
+> Note: Make sure that the `Options.Default.WithMicrosoftSettings` is passed in as `options` when creating the container. This makes the provider compliant with the default provider from Microsoft. 
 

--- a/src/.vscode/tasks.json
+++ b/src/.vscode/tasks.json
@@ -5,12 +5,17 @@
     "tasks": [
         {
             "label": "build",
-            "command": "dotnet build",
-            "type": "shell",
-            "group": "build",
-            "presentation": {
-                "reveal": "always"
+            "command": "dotnet",
+            "type": "process",
+            "group": {
+                "kind": "build",
+                "isDefault": true
             },
+            "args": [
+                "build",
+                "${workspaceFolder}/LightInject.Microsoft.DependencyInjection.Tests/LightInject.Microsoft.DependencyInjection.Tests.csproj",
+                "/property:GenerateFullPaths=true"
+            ],
             "problemMatcher": "$msCompile"
         },
         {

--- a/src/LightInject.Microsoft.DependencyInjection.Tests/LightInjectSpecificationTests.cs
+++ b/src/LightInject.Microsoft.DependencyInjection.Tests/LightInjectSpecificationTests.cs
@@ -9,8 +9,7 @@
     {
         protected override IServiceProvider CreateServiceProvider(IServiceCollection serviceCollection)
         {
-            var container = new ServiceContainer(new ContainerOptions() { EnablePropertyInjection = false, DefaultServiceSelector = services => services.SingleOrDefault(string.IsNullOrWhiteSpace) ?? services.Last() });                        
-            return container.CreateServiceProvider(serviceCollection);            
-        }                
+            return serviceCollection.CreateLightInjectServiceProvider();
+        }
     }
 }

--- a/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceCollectionTests.cs
+++ b/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceCollectionTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Text;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace LightInject.Microsoft.DependencyInjection.Tests
+{
+    public class ServiceCollectionTests
+    {
+        [Fact]
+        public void ShouldCreateServiceProviderFromServiceCollection()
+        {
+            var serviceCollection = new ServiceCollection();
+            var provider = serviceCollection.CreateLightInjectServiceProvider();
+            Assert.IsAssignableFrom<IServiceProvider>(provider);
+        }
+
+        [Fact]
+        public void ShouldCreateServiceProviderWithOptionsFromServiceCollection()
+        {
+            StringBuilder log = new StringBuilder();
+            ContainerOptions.Default.LogFactory = (t) => l => log.AppendLine(l.Message);
+
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton("42");
+            var provider = serviceCollection.CreateLightInjectServiceProvider();
+            var instance = provider.GetService<string>();
+            Assert.IsAssignableFrom<IServiceProvider>(provider);
+
+            Assert.NotEmpty(log.ToString());
+        }
+    }
+}

--- a/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceContainerTests.cs
@@ -1,0 +1,20 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace LightInject.Microsoft.DependencyInjection.Tests
+{
+    public class ServiceContainerTests
+    {
+        [Fact]
+        public void ShouldThrowExceptionWhenProviderIsCreatedTwice()
+        {
+            var container = new ServiceContainer();
+            var serviceCollection = new ServiceCollection();
+
+            var provider = container.CreateServiceProvider(serviceCollection);
+
+            Assert.Throws<InvalidOperationException>(() => container.CreateServiceProvider(serviceCollection));
+        }
+    }
+}

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -213,7 +213,6 @@ namespace LightInject.Microsoft.DependencyInjection
     /// </summary>
     public class LightInjectServiceProviderFactory : IServiceProviderFactory<IServiceContainer>
     {
-        private readonly ContainerOptions options;
         private IServiceCollection services;
         private readonly Func<IServiceContainer> containerFactory;
 

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -84,6 +84,11 @@ namespace LightInject.Microsoft.DependencyInjection
         /// <returns>A configured <see cref="IServiceProvider"/>.</returns>
         public static IServiceProvider CreateServiceProvider(this IServiceContainer container, IServiceCollection serviceCollection)
         {
+            if (container.ScopeManagerProvider.GetScopeManager(container).CurrentScope != null)
+            {
+                throw new InvalidOperationException("CreateServiceProvider can only be called once per IServiceContainer instance.");
+            }
+
             var rootScope = container.BeginScope();
             rootScope.Completed += (a, s) => container.Dispose();
             container.Register<IServiceProvider>(factory => new LightInjectServiceProvider(container), new PerRootScopeLifetime(rootScope));

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -51,7 +51,7 @@ namespace LightInject.Microsoft.DependencyInjection
         /// <summary>
         /// Create a new <see cref="IServiceProvider"/> from the given <paramref name="serviceCollection"/>.
         /// </summary>
-        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> from which to create an <see cref="IServiceProvider"/></param>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> from which to create an <see cref="IServiceProvider"/>.</param>
         /// <returns>An <see cref="IServiceProvider"/> that is backed by an <see cref="IServiceContainer"/>.</returns>
         public static IServiceProvider CreateLightInjectServiceProvider(this IServiceCollection serviceCollection)
         {
@@ -61,7 +61,7 @@ namespace LightInject.Microsoft.DependencyInjection
         /// <summary>
         /// Create a new <see cref="IServiceProvider"/> from the given <paramref name="serviceCollection"/>.
         /// </summary>
-        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> from which to create an <see cref="IServiceProvider"/></param>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> from which to create an <see cref="IServiceProvider"/>.</param>
         /// <param name="options">The <see cref="ContainerOptions"/> to be used when creating the <see cref="ServiceContainer"/>.</param>
         /// <returns>An <see cref="IServiceProvider"/> that is backed by an <see cref="IServiceContainer"/>.</returns>
         public static IServiceProvider CreateLightInjectServiceProvider(this IServiceCollection serviceCollection, ContainerOptions options)
@@ -203,7 +203,7 @@ namespace LightInject.Microsoft.DependencyInjection
         /// Sets up the <see cref="ContainerOptions"/> to be compliant with the conventions used in Microsoft.Extensions.DependencyInjection.
         /// </summary>
         /// <param name="options">The target <see cref="ContainerOptions"/>.</param>
-        /// <returns><see cref="ContainerOptions"/></returns>
+        /// <returns><see cref="ContainerOptions"/>.</returns>
         public static ContainerOptions WithMicrosoftSettings(this ContainerOptions options)
         {
             options.DefaultServiceSelector = serviceNames => serviceNames.SingleOrDefault(string.IsNullOrWhiteSpace) ?? serviceNames.Last();
@@ -212,14 +212,14 @@ namespace LightInject.Microsoft.DependencyInjection
         }
     }
 
-
     /// <summary>
     /// Creates a LightInject container builder.
     /// </summary>
     public class LightInjectServiceProviderFactory : IServiceProviderFactory<IServiceContainer>
     {
-        private IServiceCollection services;
         private readonly Func<IServiceContainer> containerFactory;
+
+        private IServiceCollection services;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="LightInjectServiceProviderFactory"/> class.
@@ -246,7 +246,6 @@ namespace LightInject.Microsoft.DependencyInjection
         {
             this.containerFactory = () => serviceContainer;
         }
-
 
         /// <inheritdoc/>
         public IServiceContainer CreateBuilder(IServiceCollection services)

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -21,7 +21,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ******************************************************************************
-    LightInject.Microsoft.DependencyInjection version 2.1.0
+    LightInject.Microsoft.DependencyInjection version 2.2.0
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/
@@ -42,6 +42,34 @@ namespace LightInject.Microsoft.DependencyInjection
     using System.Linq;
     using System.Reflection;
     using global::Microsoft.Extensions.DependencyInjection;
+
+    /// <summary>
+    /// Extends the <see cref="IServiceCollection"/> interface.
+    /// </summary>
+    public static class LightInjectServiceCollectionExtensions
+    {
+        /// <summary>
+        /// Create a new <see cref="IServiceProvider"/> from the given <paramref name="serviceCollection"/>.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> from which to create an <see cref="IServiceProvider"/></param>
+        /// <returns>An <see cref="IServiceProvider"/> that is backed by an <see cref="IServiceContainer"/>.</returns>
+        public static IServiceProvider CreateLightInjectServiceProvider(this IServiceCollection serviceCollection)
+        {
+            return serviceCollection.CreateLightInjectServiceProvider(ContainerOptions.Default);
+        }
+
+        /// <summary>
+        /// Create a new <see cref="IServiceProvider"/> from the given <paramref name="serviceCollection"/>.
+        /// </summary>
+        /// <param name="serviceCollection">The <see cref="IServiceCollection"/> from which to create an <see cref="IServiceProvider"/></param>
+        /// <param name="options">The <see cref="ContainerOptions"/> to be used when creating the <see cref="ServiceContainer"/>.</param>
+        /// <returns>An <see cref="IServiceProvider"/> that is backed by an <see cref="IServiceContainer"/>.</returns>
+        public static IServiceProvider CreateLightInjectServiceProvider(this IServiceCollection serviceCollection, ContainerOptions options)
+        {
+            var container = new ServiceContainer(options.WithMicrosoftSettings());
+            return container.CreateServiceProvider(serviceCollection);
+        }
+    }
 
     /// <summary>
     /// Extends the <see cref="IServiceContainer"/> interface.

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
@@ -20,12 +20,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LightInject" Version="5.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.6.2">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
-    </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-    <PackageReference Include="StyleCop.Analyzers" Version="1.1.0-beta009">
+        <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
@@ -13,6 +13,9 @@
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>2.1.2</Version>
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LightInject" Version="5.3.0" />

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
@@ -9,21 +9,18 @@
     <RepositoryUrl>https://github.com/seesharper/LightInject.Microsoft.DependencyInjection</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageTags>Ioc Dependency-Injection Inversion-of-Control LightInject ASP.NET Entity-Framework</PackageTags>
-    <DebugType>Full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>portable</DebugType>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Version>2.1.2</Version>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Debug\netstandard2.0\LightInject.Microsoft.DependencyInjection.xml</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netstandard2.0|AnyCPU'">
-    <DocumentationFile>bin\Release\netstandard2.0\LightInject.Microsoft.DependencyInjection.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="LightInject" Version="5.3.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
-        <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.1-beta.61">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All"/>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Adds two new extensions methods for simpler usage outside of an AspNetCore application. 
 
* `CreateLightInjectServiceProvider(this IServiceCollection serviceCollection)`
* `CreateLightInjectServiceProvider(this IServiceCollection serviceCollection, ContainerOptions options)`

Updated docs to encourage the use of `LightInject.Microsoft.AspNetCore.Hosting` for AspNetCore applications.

Start using SourceLink for easier debugging. 