### PR TITLE
Register values as singleton

### DIFF
--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -21,7 +21,7 @@
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
     SOFTWARE.
 ******************************************************************************
-    LightInject.Microsoft.DependencyInjection version 3.1.0
+    LightInject.Microsoft.DependencyInjection version 3.1.2
     http://www.lightinject.net/
     http://twitter.com/bernhardrichter
 ******************************************************************************/
@@ -174,11 +174,6 @@ namespace LightInject.Microsoft.DependencyInjection
 
         private static ILifetime ResolveLifetime(ServiceDescriptor serviceDescriptor, Scope rootScope)
         {
-            if (serviceDescriptor.ImplementationInstance != null)
-            {
-                return null;
-            }
-
             ILifetime lifetime = null;
 
             switch (serviceDescriptor.Lifetime)
@@ -422,6 +417,7 @@ namespace LightInject.Microsoft.DependencyInjection
     /// <summary>
     /// An <see cref="ILifetime"/> implementation that makes it possible to mimic the notion of a root scope.
     /// </summary>
+    [LifeSpan(30)]
     internal class PerRootScopeLifetime : ILifetime, ICloneableLifeTime
     {
         private readonly object syncRoot = new object();

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
@@ -12,13 +12,13 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.1.1</Version>
+    <Version>3.2.1</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LightInject" Version="6.1.0" />
+    <PackageReference Include="LightInject" Version="6.2.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This PR fixes a bug where values was registered as a transient.

Also added the `LifeSpanAttribute` to be used later for validation