### PR TITLE
Use provided scope when invoking factory delegate

### DIFF
--- a/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceContainerTests.cs
+++ b/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceContainerTests.cs
@@ -38,5 +38,42 @@ namespace LightInject.Microsoft.DependencyInjection.Tests
 
             Assert.True(wasCalled);
         }
+
+        [Fact]
+        public void ShouldNotUseRootScopeForFactoryDelegate()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddScoped<DerivedFoo>();
+
+            serviceCollection.AddScoped<Foo>(sp =>
+            {
+                return sp.GetService<DerivedFoo>();
+            });
+
+            var provider = serviceCollection.CreateLightInjectServiceProvider(options => options.EnableCurrentScope = false);
+
+            Foo firstFoo;
+            Foo secondFoo;
+
+            using (var serviceScope = provider.CreateScope())
+            {
+                firstFoo = serviceScope.ServiceProvider.GetService<Foo>();
+            }
+
+            using (var serviceScope = provider.CreateScope())
+            {
+                secondFoo = serviceScope.ServiceProvider.GetService<Foo>();
+            }
+
+            Assert.NotSame(firstFoo, secondFoo);
+        }
+
+        public class Foo
+        {
+        }
+
+        public class DerivedFoo : Foo
+        {
+        }
     }
 }

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -216,7 +216,8 @@ namespace LightInject.Microsoft.DependencyInjection
 
         private static Func<IServiceFactory, T> CreateTypedFactoryDelegate<T>(ServiceDescriptor serviceDescriptor)
         {
-            return serviceFactory => (T)serviceDescriptor.ImplementationFactory(serviceFactory.GetInstance<IServiceProvider>());
+            //return serviceFactory => (T)serviceDescriptor.ImplementationFactory(serviceFactory.GetInstance<IServiceProvider>());
+            return serviceFactory => (T)serviceDescriptor.ImplementationFactory(new LightInjectServiceProvider(serviceFactory));
         }
     }
 

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.csproj
@@ -12,7 +12,7 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <Version>3.2.0</Version>
+    <Version>3.2.1</Version>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>


### PR DESCRIPTION
This PR fixes a bug that we found when registering a service that redirects to another service. 

The original code was 

```
            var services = new ServiceCollection();

            services.TryAddScoped<DbConnection>(sp =>
            {
                var connection = OracleClientFactory.Instance.CreateConnection();                
                connection.ConnectionString = "Data Source=vt-workt-191.dips.local/DIPS;User Id=system;Password=oracle";
                connection.Open();
                return connection;
            });

            services.TryAddTransient<IDbConnection>(sp => sp.GetRequiredService<DbConnection>());

```

What happened here was that `IDbConnection` was always resolved from the root scope and came back as a closed connection the second time it was resolved since it was closed in `Dispose`

Since we started to flow the scope in LightInject, we missed that detail in the adapter.

