### PR TITLE
Disable current scope

### DIFF
--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -235,6 +235,7 @@ namespace LightInject.Microsoft.DependencyInjection
         {
             options.DefaultServiceSelector = serviceNames => serviceNames.SingleOrDefault(string.IsNullOrWhiteSpace) ?? serviceNames.Last();
             options.EnablePropertyInjection = false;
+            options.EnableCurrentScope = false;
             return options;
         }
 


### PR DESCRIPTION
This PR disables the notion of a current scope. MS.Ex.DI does not maintain a current scope so it does not makes sense for LightInject either. 