### PR TITLE
Make sure UnderlyingSystemType is used to support non-RuntimeType factory registrations

### DIFF
--- a/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceCollectionTests.cs
+++ b/src/LightInject.Microsoft.DependencyInjection.Tests/ServiceCollectionTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Reflection;
 using System.Text;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
@@ -28,6 +29,14 @@ namespace LightInject.Microsoft.DependencyInjection.Tests
             Assert.IsAssignableFrom<IServiceProvider>(provider);
 
             Assert.NotEmpty(log.ToString());
+        }
+
+        [Fact]
+        public void ShouldSupportNonRuntimeTypeFactoryRegistrations()
+        {
+            var serviceCollection = new ServiceCollection();
+            serviceCollection.AddSingleton(new TypeDelegator(typeof(int)), _ => 42);
+            Assert.NotNull(serviceCollection.CreateLightInjectServiceProvider());
         }
     }
 }

--- a/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
+++ b/src/LightInject.Microsoft.DependencyInjection/LightInject.Microsoft.DependencyInjection.cs
@@ -212,7 +212,7 @@ namespace LightInject.Microsoft.DependencyInjection
         private static Delegate CreateFactoryDelegate(ServiceDescriptor serviceDescriptor)
         {
             var openGenericMethod = typeof(DependencyInjectionContainerExtensions).GetTypeInfo().GetDeclaredMethod("CreateTypedFactoryDelegate");
-            var closedGenericMethod = openGenericMethod.MakeGenericMethod(serviceDescriptor.ServiceType);
+            var closedGenericMethod = openGenericMethod.MakeGenericMethod(serviceDescriptor.ServiceType.UnderlyingSystemType);
             return (Delegate)closedGenericMethod.Invoke(null, new object[] { serviceDescriptor });
         }
 


### PR DESCRIPTION
Re: https://github.com/khellang/Scrutor/issues/175